### PR TITLE
fix: don’t add save package when using ng add

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "author": "Stefanie Fluin",
   "license": "MIT",
   "schematics": "./src/collection.json",
+  "ng-add": {
+    "save": false
+  },
   "dependencies": {
     "@angular-devkit/core": "^9.0.1",
     "@angular-devkit/schematics": "^9.0.1",


### PR DESCRIPTION
Since this package is used once to scafold the initial scss structure, there is no reason to add this package as a dependency.